### PR TITLE
Add import line in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The library tries to closely match the native Android & iOS login SDK APIs where
 Since sample code is worth more than one page of documentation, here are the usual cases covered:
 
 ```dart
+import 'package:flutter_facebook_login/flutter_facebook_login.dart';
+
 var facebookLogin = new FacebookLogin();
 var result = await facebookLogin.logInWithReadPermissions(['email']);
 


### PR DESCRIPTION
Having the import is useful. It is in the pub page, but having it in the sample code can save some digging when you are getting started.