### PR TITLE
Solve Permission Denial in API >= 23

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -43,7 +43,9 @@
         <activity android:name="com.facebook.FacebookActivity"
             android:configChanges=
                 "keyboard|keyboardHidden|screenLayout|screenSize|orientation"
-            android:label="@string/app_name" />
+            android:label="@string/app_name" 
+            android:exported="true"
+            />
         <activity
             android:name="com.facebook.CustomTabActivity"
             android:exported="true">


### PR DESCRIPTION
I got a problem which didn't let me work in API >= 23.
Error: 
Security Exception : Permission Denial: starting intent { act=android.intent.action.RUN flg=0x30000000 cmp= ./com.facebook.FacebookActivity has extras }

So, I found that this show happens when the app is trying to access to other apps.