### PR TITLE
Fix loginkit dependency

### DIFF
--- a/ios/flutter_facebook_login.podspec
+++ b/ios/flutter_facebook_login.podspec
@@ -15,7 +15,7 @@ A Flutter plugin for allowing users to authenticate with native Android &amp; iO
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'FBSDKLoginKit', '4.39.1'
+  s.dependency 'FBSDKLoginKit', '4.42.0'
 
   # https://github.com/flutter/flutter/issues/14161
   s.static_framework = true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_facebook_login
 description: A Flutter plugin for allowing users to authenticate with native Android &amp; iOS Facebook login SDKs.
-version: 2.0.0
+version: 2.0.1
 author: Iiro Krankka <iiro.krankka@gmail.com>
 homepage: https://github.com/roughike/flutter_facebook_login
 


### PR DESCRIPTION
Bumps the version of FBSDKLoginKit fixing a problem when solving transitive dependencies after a pod update.

Since the version of FBSDKCoreKit is not locked, a pod update downloads the latest version (4.42.0) which introduces breaking changes for the 4.39.0 version of the FBSDKLoginKit pod used by the flutter_facebook_login package.