### PR TITLE
Add dependency for FBSDKCoreKit

### DIFF
--- a/ios/flutter_facebook_login.podspec
+++ b/ios/flutter_facebook_login.podspec
@@ -16,6 +16,7 @@ A Flutter plugin for allowing users to authenticate with native Android &amp; iO
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'FBSDKLoginKit', '4.39.1'
+  s.dependency 'FBSDKCoreKit', '4.39.1'
 
   # https://github.com/flutter/flutter/issues/14161
   s.static_framework = true


### PR DESCRIPTION
The core and login versions need to be the same.