### PR TITLE
Fix FBSDKCore version

### DIFF
--- a/ios/flutter_facebook_login.podspec
+++ b/ios/flutter_facebook_login.podspec
@@ -16,6 +16,7 @@ A Flutter plugin for allowing users to authenticate with native Android &amp; iO
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'FBSDKLoginKit', '4.39.1'
+  s.dependency 'FBSDKCoreKit', '4.39.1'
 
   # https://github.com/flutter/flutter/issues/14161
   s.static_framework = true

--- a/ios/flutter_facebook_login.podspec
+++ b/ios/flutter_facebook_login.podspec
@@ -17,6 +17,7 @@ A Flutter plugin for allowing users to authenticate with native Android &amp; iO
   s.dependency 'Flutter'
   s.dependency 'FBSDKLoginKit', '4.39.1'
   s.dependency 'FBSDKCoreKit', '4.39.1'
+  s.dependency 'FBSDKShareKit', '4.39.1'
 
   # https://github.com/flutter/flutter/issues/14161
   s.static_framework = true


### PR DESCRIPTION
This PR is just a small extension to #113 in that we found that `FBSDKShareKit` as well as `FBSDKCoreKit` needed to have explicit versions set to allow the package to build in our app project on iOS.