### PR TITLE
Fixed invalid token issue on some iOS devices

### DIFF
--- a/ios/Classes/FacebookLoginPlugin.m
+++ b/ios/Classes/FacebookLoginPlugin.m
@@ -172,7 +172,7 @@
   NSArray *permissions = [accessToken.permissions allObjects];
   NSArray *declinedPermissions = [accessToken.declinedPermissions allObjects];
   NSNumber *expires = [NSNumber
-      numberWithLong:accessToken.expirationDate.timeIntervalSince1970 * 1000.0];
+      numberWithLongLong:accessToken.expirationDate.timeIntervalSince1970 * 1000.0];
 
   return @{
     @"token" : accessToken.tokenString,


### PR DESCRIPTION
Access token is passed to flutter from objective c as a `long`. On some iOS devices long is only 32 bit, which is too short for UTC timestamp in milliseconds. The expired time of the token is then set to somewhere in the 1970 so token is always invalid and `isLoggedIn` always returns `false`.

Using `long long` fixes the issue, since `long long` is 64bit on all devices.