### PR TITLE
specify FBSDKCoreKit version

### DIFF
--- a/ios/flutter_facebook_login.podspec
+++ b/ios/flutter_facebook_login.podspec
@@ -15,6 +15,7 @@ A Flutter plugin for allowing users to authenticate with native Android &amp; iO
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
+  s.dependency 'FBSDKCoreKit', '4.39.1'
   s.dependency 'FBSDKLoginKit', '4.39.1'
 
   # https://github.com/flutter/flutter/issues/14161


### PR DESCRIPTION
FBSDKLoginKit was pulling the latest version of FBSDKCoreKit (transitive dependency issue)