### PR TITLE
v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* [#128](https://github.com/roughike/flutter_facebook_login/pull/128): Pin down FBSDKCoreKit to the same version as FBSDKLoginKit.
+
 ## 2.0.0
 
 * **Breaking change:** migrate from the deprecated original Android Support Library to AndroidX. This shouldn't result in any functional changes, but it requires any Android apps using this plugin to [also migrate](https://flutter.dev/docs/development/packages-and-plugins/androidx-compatibility) if they're using the original support library.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_facebook_login
 description: A Flutter plugin for allowing users to authenticate with native Android &amp; iOS Facebook login SDKs.
-version: 2.0.0
+version: 2.0.1
 author: Iiro Krankka <iiro.krankka@gmail.com>
 homepage: https://github.com/roughike/flutter_facebook_login
 


### PR DESCRIPTION
Changes:
* [#128](https://github.com/roughike/flutter_facebook_login/pull/128): Pin down FBSDKCoreKit to the same version as FBSDKLoginKit.