### PR TITLE
[doc] Improve iOS Info.plist documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,18 @@ This assumes that you've done the _"Register and Configure Your App with Faceboo
 After you've done that, find out what your _Facebook App ID_ is. You can find your Facebook App ID in your Facebook App's dashboard in the Facebook developer console.
 
 Once you have the Facebook App ID figured out, then you'll just have to copy-paste the following to your _Info.plist_ file, before the ending `</dict></plist>` tags.
+(**NOTE**: If you are using this plugin in conjunction with for example google_sign_in plugin, which also requires you to add `CFBundleURLTypes` key into _Info.plist_ file, you need to merge them together).
 
 **\<your project root\>/ios/Runner/Info.plist**
 
 ```xml
 <key>CFBundleURLTypes</key>
 <array>
+    <!--
+    <dict>
+    ... Some other CFBundleURLTypes definition.
+    </dict>
+    -->
     <dict>
         <key>CFBundleURLSchemes</key>
         <array>


### PR DESCRIPTION
I just stumbled upon the problem that once following (otherwise nice) docs, I missed that in my Info.plist there is already `CFBundleURLTypes` defined by google_sign_in plugin. This led to some undecipherable platform errors:
```
(
	0   CoreFoundation                      0x000000011042f8db __exceptionPreprocess + 331
	1   libobjc.A.dylib                     0x000000010f59cac5 objc_exception_throw + 48
	2   CoreFoundation                      0x000000011042f735 +[NSException raise:format:] + 197
	3   Runner                              0x00000001094c4288 -[GIDSignIn signInWithOptions:] + 242
	4   Runner                              0x00000001094c087d -[GIDSignIn signIn] + 64
	5   Runner                              0x0000000108fef151 -[FLTGoogleSignInPlugin handleMethodCall:result:] + 2257
	6   Flutter                             0x000000010b870818 __45-[FlutterMethodChannel setMethodCallHandler:]_block_invoke + 115
	7   Flutter                             0x000000010b810476 _ZNK7flu<…>
Lost connection to device.
Exited (sigterm)
```
So I added a note about it to docs