### PR TITLE
Bump SDK deps to 5.5.0 and remove deprecated SDK methods and usages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.0.0
-* Update Android & iOS Facebook Login dependencies to `5.5.0`
+* Update Android & iOS Facebook Login dependencies to `5.5`
 * Removed deprecated method `loginWithPublishPermissions` and renamed `loginWithReadPermission` to `login`
 * The `behavior` parameter is now ignored on iOS as it is not supported anymore by the Facebook Login SDK
 * Bump iOS deployment target to `9.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.0
+* Update Android & iOS Facebook Login dependencies to `5.5.0`
+* Removed deprecated method `loginWithPublishPermissions` and renamed `loginWithReadPermission` to `login`
+* The `behavior` parameter is now ignored on iOS as it is not supported anymore by the Facebook Login SDK
+* Bump iOS deployment target to `9.0`
+
 ## 2.0.1
 
 * [#128](https://github.com/roughike/flutter_facebook_login/pull/128): Pin down FBSDKCoreKit to the same version as FBSDKLoginKit.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    api 'com.facebook.android:facebook-login:4.39.0'
+    api 'com.facebook.android:facebook-login:5.5.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    api 'com.facebook.android:facebook-login:5.5.0'
+    api 'com.facebook.android:facebook-login:5.5.1'
 }

--- a/android/src/main/java/com/roughike/facebooklogin/facebooklogin/FacebookLoginPlugin.java
+++ b/android/src/main/java/com/roughike/facebooklogin/facebooklogin/FacebookLoginPlugin.java
@@ -19,8 +19,7 @@ public class FacebookLoginPlugin implements MethodCallHandler {
 
     private static final String ERROR_UNKNOWN_LOGIN_BEHAVIOR = "unknown_login_behavior";
 
-    private static final String METHOD_LOG_IN_WITH_READ_PERMISSIONS = "loginWithReadPermissions";
-    private static final String METHOD_LOG_IN_WITH_PUBLISH_PERMISSIONS = "loginWithPublishPermissions";
+    private static final String METHOD_LOG_IN = "logIn";
     private static final String METHOD_LOG_OUT = "logOut";
     private static final String METHOD_GET_CURRENT_ACCESS_TOKEN = "getCurrentAccessToken";
 
@@ -50,19 +49,12 @@ public class FacebookLoginPlugin implements MethodCallHandler {
         LoginBehavior loginBehavior;
 
         switch (call.method) {
-            case METHOD_LOG_IN_WITH_READ_PERMISSIONS:
+            case METHOD_LOG_IN:
                 loginBehaviorStr = call.argument(ARG_LOGIN_BEHAVIOR);
                 loginBehavior = loginBehaviorFromString(loginBehaviorStr, result);
-                List<String> readPermissions = call.argument(ARG_PERMISSIONS);
+                List<String> permissions = call.argument(ARG_PERMISSIONS);
 
-                delegate.logInWithReadPermissions(loginBehavior, readPermissions, result);
-                break;
-            case METHOD_LOG_IN_WITH_PUBLISH_PERMISSIONS:
-                loginBehaviorStr = call.argument(ARG_LOGIN_BEHAVIOR);
-                loginBehavior = loginBehaviorFromString(loginBehaviorStr, result);
-                List<String> publishPermissions = call.argument(ARG_PERMISSIONS);
-
-                delegate.logInWithPublishPermissions(loginBehavior, publishPermissions, result);
+                delegate.logIn(loginBehavior, permissions, result);
                 break;
             case METHOD_LOG_OUT:
                 delegate.logOut(result);
@@ -113,20 +105,12 @@ public class FacebookLoginPlugin implements MethodCallHandler {
             registrar.addActivityResultListener(resultDelegate);
         }
 
-        public void logInWithReadPermissions(
+        public void logIn(
                 LoginBehavior loginBehavior, List<String> permissions, Result result) {
-            resultDelegate.setPendingResult(METHOD_LOG_IN_WITH_READ_PERMISSIONS, result);
+            resultDelegate.setPendingResult(METHOD_LOG_IN, result);
 
             loginManager.setLoginBehavior(loginBehavior);
-            loginManager.logInWithReadPermissions(registrar.activity(), permissions);
-        }
-
-        public void logInWithPublishPermissions(
-                LoginBehavior loginBehavior, List<String> permissions, Result result) {
-            resultDelegate.setPendingResult(METHOD_LOG_IN_WITH_PUBLISH_PERMISSIONS, result);
-
-            loginManager.setLoginBehavior(loginBehavior);
-            loginManager.logInWithPublishPermissions(registrar.activity(), permissions);
+            loginManager.logIn(registrar.activity(), permissions);
         }
 
         public void logOut(Result result) {

--- a/example/ios/Flutter/Debug.xcconfig
+++ b/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Flutter/Release.xcconfig
+++ b/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,7 +17,7 @@ class _MyAppState extends State<MyApp> {
 
   Future<Null> _login() async {
     final FacebookLoginResult result =
-        await facebookSignIn.logInWithReadPermissions(['email']);
+        await facebookSignIn.logIn(['email']);
 
     switch (result.status) {
       case FacebookLoginStatus.loggedIn:

--- a/ios/Classes/FacebookLoginPlugin.m
+++ b/ios/Classes/FacebookLoginPlugin.m
@@ -54,22 +54,10 @@
 
 - (void)handleMethodCall:(FlutterMethodCall *)call
                   result:(FlutterResult)result {
-  if ([@"loginWithReadPermissions" isEqualToString:call.method]) {
-    FBSDKLoginBehavior behavior =
-        [self loginBehaviorFromString:call.arguments[@"behavior"]];
+  if ([@"logIn" isEqualToString:call.method]) {
     NSArray *permissions = call.arguments[@"permissions"];
 
-    [self loginWithReadPermissions:behavior
-                       permissions:permissions
-                            result:result];
-  } else if ([@"loginWithPublishPermissions" isEqualToString:call.method]) {
-    FBSDKLoginBehavior behavior =
-        [self loginBehaviorFromString:call.arguments[@"behavior"]];
-    NSArray *permissions = call.arguments[@"permissions"];
-
-    [self loginWithPublishPermissions:behavior
-                          permissions:permissions
-                               result:result];
+    [self loginWithPermissions:permissions result:result];
   } else if ([@"logOut" isEqualToString:call.method]) {
     [self logOut:result];
   } else if ([@"getCurrentAccessToken" isEqualToString:call.method]) {
@@ -79,30 +67,10 @@
   }
 }
 
-- (FBSDKLoginBehavior)loginBehaviorFromString:(NSString *)loginBehaviorStr {
-  if ([@[ @"nativeWithFallback", @"nativeOnly" ]
-          containsObject:loginBehaviorStr]) {
-    return FBSDKLoginBehaviorNative;
-  } else if ([@"webOnly" isEqualToString:loginBehaviorStr]) {
-    return FBSDKLoginBehaviorBrowser;
-  } else if ([@"webViewOnly" isEqualToString:loginBehaviorStr]) {
-    return FBSDKLoginBehaviorWeb;
-  } else {
-    NSString *message = [NSString
-        stringWithFormat:@"Unknown login behavior: %@", loginBehaviorStr];
-
-    @throw [NSException exceptionWithName:@"InvalidLoginBehaviorException"
-                                   reason:message
-                                 userInfo:nil];
-  }
-}
-
-- (void)loginWithReadPermissions:(FBSDKLoginBehavior)behavior
-                     permissions:(NSArray *)permissions
+- (void)loginWithPermissions:(NSArray *)permissions
                           result:(FlutterResult)result {
-  [loginManager setLoginBehavior:behavior];
   [loginManager
-      logInWithReadPermissions:permissions
+      logInWithPermissions:permissions
             fromViewController:nil
                        handler:^(FBSDKLoginManagerLoginResult *loginResult,
                                  NSError *error) {
@@ -110,21 +78,6 @@
                                           result:result
                                            error:error];
                        }];
-}
-
-- (void)loginWithPublishPermissions:(FBSDKLoginBehavior)behavior
-                        permissions:(NSArray *)permissions
-                             result:(FlutterResult)result {
-  [loginManager setLoginBehavior:behavior];
-  [loginManager
-      logInWithPublishPermissions:permissions
-               fromViewController:nil
-                          handler:^(FBSDKLoginManagerLoginResult *loginResult,
-                                    NSError *error) {
-                            [self handleLoginResult:loginResult
-                                             result:result
-                                              error:error];
-                          }];
 }
 
 - (void)logOut:(FlutterResult)result {

--- a/ios/Classes/FacebookLoginPlugin.m
+++ b/ios/Classes/FacebookLoginPlugin.m
@@ -125,7 +125,7 @@
   NSArray *permissions = [accessToken.permissions allObjects];
   NSArray *declinedPermissions = [accessToken.declinedPermissions allObjects];
   NSNumber *expires = [NSNumber
-      numberWithLong:accessToken.expirationDate.timeIntervalSince1970 * 1000.0];
+      numberWithLongLong:accessToken.expirationDate.timeIntervalSince1970 * 1000.0];
 
   return @{
     @"token" : accessToken.tokenString,

--- a/ios/flutter_facebook_login.podspec
+++ b/ios/flutter_facebook_login.podspec
@@ -15,12 +15,11 @@ A Flutter plugin for allowing users to authenticate with native Android &amp; iO
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'FBSDKCoreKit', '4.39.1'
-  s.dependency 'FBSDKLoginKit', '4.39.1'
+  s.dependency 'FBSDKCoreKit', '~> 5.5'
+  s.dependency 'FBSDKLoginKit', '~> 5.5'
 
   # https://github.com/flutter/flutter/issues/14161
   s.static_framework = true
   
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
 end
-

--- a/lib/flutter_facebook_login.dart
+++ b/lib/flutter_facebook_login.dart
@@ -17,7 +17,7 @@ import 'src/clock.dart';
 /// ```dart
 /// final facebookLogin = FacebookLogin();
 /// final result =
-///   await facebookLogin.logInWithReadPermissions(['email']);
+///   await facebookLogin.logInWithPermissions(['email']);
 ///
 /// switch (result.status) {
 ///   case FacebookLoginStatus.loggedIn:
@@ -99,38 +99,11 @@ class FacebookLogin {
   /// Returns a [FacebookLoginResult] that contains relevant information about
   /// the current login status. For sample code, see the [FacebookLogin] class-
   /// level documentation.
-  Future<FacebookLoginResult> logInWithReadPermissions(
+  Future<FacebookLoginResult> logIn(
     List<String> permissions,
   ) async {
     final Map<dynamic, dynamic> result =
-        await channel.invokeMethod('loginWithReadPermissions', {
-      'behavior': _currentLoginBehaviorAsString(),
-      'permissions': permissions,
-    });
-
-    return _deliverResult(
-        FacebookLoginResult._(result.cast<String, dynamic>()));
-  }
-
-  /// Logs the user in with the requested publish permissions.
-  ///
-  /// This will throw an exception from the native side if the [permissions]
-  /// list contains any permissions that are not classified as read permissions.
-  ///
-  /// If called right after receiving a result from [logInWithReadPermissions],
-  /// this method may fail. It is recommended to call this method right before
-  /// needing a specific publish permission, in a context where it makes sense
-  /// to the user. For example, a good place to call this method would be when
-  /// the user is about to post something to Facebook by using your app.
-  ///
-  /// Returns a [FacebookLoginResult] that contains relevant information about
-  /// the current login status. For sample code, see the [FacebookLogin] class-
-  /// level documentation.
-  Future<FacebookLoginResult> loginWithPublishPermissions(
-    List<String> permissions,
-  ) async {
-    final Map<dynamic, dynamic> result =
-        await channel.invokeMethod('loginWithPublishPermissions', {
+        await channel.invokeMethod('logIn', {
       'behavior': _currentLoginBehaviorAsString(),
       'permissions': permissions,
     });
@@ -143,17 +116,12 @@ class FacebookLogin {
   ///
   /// NOTE: On iOS, this behaves in an unwanted way. As far the Login SDK is
   /// concerned, the access token and session is cleared upon logging out.
-  /// However, when using [FacebookLoginBehavior.webOnly], the WKViewController
-  /// managed by Safari remembers the user indefinitely.
+  /// However, ViewController managed by Safari remembers the user indefinitely.
   ///
   /// This blocks the user from logging in with any other account than the one
-  /// they used the first time. This same issue is also present when using
-  /// [FacebookLoginBehavior.nativeWithFallback] in the case where the user
-  /// doesn't have a native Facebook app installed.
+  /// they used the first time.
   ///
-  /// Using [FacebookLoginBehavior.webViewOnly] resolves this issue.
-  ///
-  /// For more, see: https://github.com/roughike/flutter_facebook_login/issues/4
+  /// For more, see: https://github.com/facebook/facebook-swift-sdk/issues/215
   Future<void> logOut() async => channel.invokeMethod('logOut');
 
   String _currentLoginBehaviorAsString() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_facebook_login
 description: A Flutter plugin for allowing users to authenticate with native Android &amp; iOS Facebook login SDKs.
-version: 2.0.1
+version: 3.0.0
 author: Iiro Krankka <iiro.krankka@gmail.com>
 homepage: https://github.com/roughike/flutter_facebook_login
 

--- a/test/custom_matchers.dart
+++ b/test/custom_matchers.dart
@@ -1,18 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 
-Matcher isReadPermissionLoginWithBehavior(String behavior) {
+Matcher isLoginWithBehavior(String behavior) {
   return isMethodCall(
-    'loginWithReadPermissions',
-    arguments: {
-      'behavior': behavior,
-      'permissions': [],
-    },
-  );
-}
-
-Matcher isPublishPermissionLoginWithBehavior(String behavior) {
-  return isMethodCall(
-    'loginWithPublishPermissions',
+    'logIn',
     arguments: {
       'behavior': behavior,
       'permissions': [],

--- a/test/facebook_login_test.dart
+++ b/test/facebook_login_test.dart
@@ -93,7 +93,7 @@ void main() {
     test('$FacebookAccessToken#toMap()', () async {
       setMethodCallResponse(kLoggedInResponse);
 
-      final result = await sut.logInWithReadPermissions([]);
+      final result = await sut.logIn([]);
       final map = result.accessToken.toMap();
 
       expect(
@@ -134,27 +134,17 @@ void main() {
     test('loginBehavior - nativeWithFallback is the default', () async {
       setMethodCallResponse(kCancelledByUserResponse);
 
-      await sut.logInWithReadPermissions(['email']);
-      await sut.loginWithPublishPermissions(['publish_actions']);
+      await sut.logIn(['email']);
 
       expect(
         log,
         [
           isMethodCall(
-            'loginWithReadPermissions',
+            'logIn',
             arguments: {
               'behavior': 'nativeWithFallback',
               'permissions': [
                 'email',
-              ],
-            },
-          ),
-          isMethodCall(
-            'loginWithPublishPermissions',
-            arguments: {
-              'behavior': 'nativeWithFallback',
-              'permissions': [
-                'publish_actions',
               ],
             },
           ),
@@ -166,40 +156,32 @@ void main() {
       setMethodCallResponse(kLoggedInResponse);
 
       sut.loginBehavior = FacebookLoginBehavior.nativeOnly;
-      await sut.logInWithReadPermissions([]);
-      await sut.loginWithPublishPermissions([]);
+      await sut.logIn([]);
 
       sut.loginBehavior = FacebookLoginBehavior.webOnly;
-      await sut.logInWithReadPermissions([]);
-      await sut.loginWithPublishPermissions([]);
+      await sut.logIn([]);
 
       sut.loginBehavior = FacebookLoginBehavior.webViewOnly;
-      await sut.logInWithReadPermissions([]);
-      await sut.loginWithPublishPermissions([]);
+      await sut.logIn([]);
 
       sut.loginBehavior = FacebookLoginBehavior.nativeWithFallback;
-      await sut.logInWithReadPermissions([]);
-      await sut.loginWithPublishPermissions([]);
+      await sut.logIn([]);
 
       expect(
         log,
         [
-          isReadPermissionLoginWithBehavior('nativeOnly'),
-          isPublishPermissionLoginWithBehavior('nativeOnly'),
-          isReadPermissionLoginWithBehavior('webOnly'),
-          isPublishPermissionLoginWithBehavior('webOnly'),
-          isReadPermissionLoginWithBehavior('webViewOnly'),
-          isPublishPermissionLoginWithBehavior('webViewOnly'),
-          isReadPermissionLoginWithBehavior('nativeWithFallback'),
-          isPublishPermissionLoginWithBehavior('nativeWithFallback'),
+          isLoginWithBehavior('nativeOnly'),
+          isLoginWithBehavior('webOnly'),
+          isLoginWithBehavior('webViewOnly'),
+          isLoginWithBehavior('nativeWithFallback'),
         ],
       );
     });
 
-    test('loginWithReadPermissions - user logged in', () async {
+    test('login - user logged in', () async {
       setMethodCallResponse(kLoggedInResponse);
 
-      final result = await sut.logInWithReadPermissions([
+      final result = await sut.logIn([
         'read_permission_1',
         'read_permission_2',
       ]);
@@ -211,7 +193,7 @@ void main() {
         log,
         [
           isMethodCall(
-            'loginWithReadPermissions',
+            'logIn',
             arguments: {
               'behavior': 'nativeWithFallback',
               'permissions': [
@@ -224,66 +206,19 @@ void main() {
       );
     });
 
-    test('loginWithReadPermissions - cancelled by user', () async {
+    test('login - cancelled by user', () async {
       setMethodCallResponse(kCancelledByUserResponse);
 
-      final result = await sut.logInWithReadPermissions([]);
+      final result = await sut.logIn([]);
 
       expect(result.status, FacebookLoginStatus.cancelledByUser);
       expect(result.accessToken, isNull);
     });
 
-    test('loginWithReadPermissions - error', () async {
+    test('login - error', () async {
       setMethodCallResponse(kErrorResponse);
 
-      final result = await sut.logInWithReadPermissions([]);
-
-      expect(result.status, FacebookLoginStatus.error);
-      expect(result.errorMessage, 'test error message');
-      expect(result.accessToken, isNull);
-    });
-
-    test('loginWithPublishPermissions - user logged in', () async {
-      setMethodCallResponse(kLoggedInResponse);
-
-      final result = await sut.loginWithPublishPermissions([
-        'publish_permission_1',
-        'publish_permission_2',
-      ]);
-
-      expect(result.status, FacebookLoginStatus.loggedIn);
-      expectAccessTokenParsedCorrectly(result.accessToken);
-
-      expect(
-        log,
-        [
-          isMethodCall(
-            'loginWithPublishPermissions',
-            arguments: {
-              'behavior': 'nativeWithFallback',
-              'permissions': [
-                'publish_permission_1',
-                'publish_permission_2',
-              ],
-            },
-          ),
-        ],
-      );
-    });
-
-    test('loginWithPublishPermissions - cancelled by user', () async {
-      setMethodCallResponse(kCancelledByUserResponse);
-
-      final result = await sut.loginWithPublishPermissions([]);
-
-      expect(result.status, FacebookLoginStatus.cancelledByUser);
-      expect(result.accessToken, isNull);
-    });
-
-    test('loginWithPublishPermissions - error', () async {
-      setMethodCallResponse(kErrorResponse);
-
-      final result = await sut.loginWithPublishPermissions([]);
+      final result = await sut.logIn([]);
 
       expect(result.status, FacebookLoginStatus.error);
       expect(result.errorMessage, 'test error message');


### PR DESCRIPTION
* Update Android & iOS Facebook Login dependencies to `5.5.0`
* Removed deprecated method `loginWithPublishPermissions` and renamed `loginWithReadPermission` to `login`
* The `behavior` parameter is now ignored on iOS as it is not supported anymore by the Facebook Login SDK
* Bump iOS deployment target to `9.0`