### PR TITLE
v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Update Android & iOS Facebook Login dependencies to `5.5`
 * Removed deprecated method `loginWithPublishPermissions` and renamed `loginWithReadPermission` to `login`
 * The `behavior` parameter is now ignored on iOS as it is not supported anymore by the Facebook Login SDK
+* #122: Fix expiration date crashes in 32-bit iOS devices.
 * Bump iOS deployment target to `9.0`
 
 ## 2.0.1

--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ Done!
 
 This assumes that you've done the _"Register and Configure Your App with Facebook"_ step in the
 [the Facebook Login documentation for iOS site](https://developers.facebook.com/docs/facebook-login/ios).
-(**Note**: you can skip "Step 2: Set up Your Development Environment").
+(**Note**: you can skip "Step 2: Set up Your Development Environment" and "Step 5: Connect Your App Delegate").
 
 After you've done that, find out what your _Facebook App ID_ is. You can find your Facebook App ID in your Facebook App's dashboard in the Facebook developer console.
 
 Once you have the Facebook App ID figured out, then you'll just have to copy-paste the following to your _Info.plist_ file, before the ending `</dict></plist>` tags.
-(**NOTE**: If you are using this plugin in conjunction with for example google_sign_in plugin, which also requires you to add `CFBundleURLTypes` key into _Info.plist_ file, you need to merge them together).
+(**NOTE**: If you are using this plugin in conjunction with for example `google_sign_in` plugin, which also requires you to add `CFBundleURLTypes` key into _Info.plist_ file, you need to merge them together).
 
 **\<your project root\>/ios/Runner/Info.plist**
 
@@ -196,9 +196,12 @@ The `profile` variable will now contain the following information:
 
 ### Troubleshooting
 
-If you haven't complete AndroidX setup you may face app crashes.
+If you haven't completed AndroidX setup in your Flutter project, your project might not build.
 The simple solution is adding 2 lines in your android/gradle.properties:
+
 ```
 android.useAndroidX=true
 android.enableJetifier=true
 ```
+
+For more, see ["AndroidX compatibility" in the official Flutter documentation](https://flutter.dev/docs/development/packages-and-plugins/androidx-compatibility).

--- a/example/ios/Flutter/flutter_export_environment.sh
+++ b/example/ios/Flutter/flutter_export_environment.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# This is a generated file; do not edit or check into version control.
+export "FLUTTER_ROOT=/Users/iirokrankka/flutter"
+export "FLUTTER_APPLICATION_PATH=/Users/iirokrankka/flutter_facebook_login/example"
+export "FLUTTER_TARGET=/Users/iirokrankka/flutter_facebook_login/example/lib/main.dart"
+export "FLUTTER_BUILD_DIR=build"
+export "SYMROOT=${SOURCE_ROOT}/../build/ios"
+export "FLUTTER_FRAMEWORK_DIR=/Users/iirokrankka/flutter/bin/cache/artifacts/engine/ios"
+export "TRACK_WIDGET_CREATION=true"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,36 +1,41 @@
 PODS:
-  - Bolts (1.8.4):
-    - Bolts/AppLinks (= 1.8.4)
-    - Bolts/Tasks (= 1.8.4)
-  - Bolts/AppLinks (1.8.4):
-    - Bolts/Tasks
-  - Bolts/Tasks (1.8.4)
-  - FBSDKCoreKit (4.29.0):
-    - Bolts (~> 1.7)
-  - FBSDKLoginKit (4.29.0):
-    - FBSDKCoreKit
+  - FBSDKCoreKit (5.6.0):
+    - FBSDKCoreKit/Basics (= 5.6.0)
+    - FBSDKCoreKit/Core (= 5.6.0)
+  - FBSDKCoreKit/Basics (5.6.0)
+  - FBSDKCoreKit/Core (5.6.0):
+    - FBSDKCoreKit/Basics
+  - FBSDKLoginKit (5.6.0):
+    - FBSDKLoginKit/Login (= 5.6.0)
+  - FBSDKLoginKit/Login (5.6.0):
+    - FBSDKCoreKit (~> 5.0)
   - Flutter (1.0.0)
   - flutter_facebook_login (0.0.1):
-    - FBSDKLoginKit (~> 4.29)
+    - FBSDKCoreKit (~> 5.5)
+    - FBSDKLoginKit (~> 5.5)
     - Flutter
 
 DEPENDENCIES:
-  - Flutter (from `/Users/ironman/flutter/bin/cache/artifacts/engine/ios`)
-  - flutter_facebook_login (from `/Users/ironman/FlutterProjects/facebook_login/ios`)
+  - Flutter (from `/Users/iirokrankka/flutter/bin/cache/artifacts/engine/ios`)
+  - flutter_facebook_login (from `/Users/iirokrankka/flutter_facebook_login/ios`)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - FBSDKCoreKit
+    - FBSDKLoginKit
 
 EXTERNAL SOURCES:
   Flutter:
-    :path: /Users/ironman/flutter/bin/cache/artifacts/engine/ios
+    :path: "/Users/iirokrankka/flutter/bin/cache/artifacts/engine/ios"
   flutter_facebook_login:
-    :path: /Users/ironman/FlutterProjects/facebook_login/ios
+    :path: "/Users/iirokrankka/flutter_facebook_login/ios"
 
 SPEC CHECKSUMS:
-  Bolts: 8a7995239dbe724f9cba2248b766d48b7ebdd322
-  FBSDKCoreKit: 6f139173dc63a1deaff4430a55f2fe5bb222d2af
-  FBSDKLoginKit: 56a057ca6822535ea0faa25f57a7c41edb697fd4
-  Flutter: d674e78c937094a75ac71dd77e921e840bea3dbf
-  flutter_facebook_login: 8570fe85a9b988b19503530a85bfce2b3b847145
+  FBSDKCoreKit: d6655a343868d4bb5c29a60859bab07c3be14a0b
+  FBSDKLoginKit: c5a623de88a6b0cda35b35582921f6cec2efcc36
+  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  flutter_facebook_login: 0266e8cf236ad20f17d377c4251c582638d8bef7
 
 PODFILE CHECKSUM: 3098c51a7edbd004c9f2b45eca5eb135d6f3ff27
 
-COCOAPODS: 1.3.0.beta.1
+COCOAPODS: 1.7.5

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 2D5378251FAA1A9400D5DBA9 /* flutter_assets */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -43,9 +42,10 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		25C17999D21EE2A5234707B6 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
+		48E8E67ED89ACADA66EFC271 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		6277276A288ACF1BC3AB10A8 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -77,6 +77,8 @@
 		6E0A99305A5C2BB9B16C1BC9 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				48E8E67ED89ACADA66EFC271 /* Pods-Runner.debug.xcconfig */,
+				6277276A288ACF1BC3AB10A8 /* Pods-Runner.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -84,7 +86,6 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
-				2D5378251FAA1A9400D5DBA9 /* flutter_assets */,
 				3B80C3931E831B6300D905FE /* App.framework */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEBA1CF902C7004384FC /* Flutter.framework */,
@@ -214,7 +215,6 @@
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
-				2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -242,13 +242,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh",
+				"${PODS_ROOT}/FBSDKCoreKit/FacebookSDKStrings.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FacebookSDKStrings.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
@@ -271,13 +274,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${PODS_ROOT}/../../../../flutter/bin/cache/artifacts/engine/ios/Flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		EB583A184DFCF138ECA68F0E /* [CP] Check Pods Manifest.lock */ = {
@@ -286,13 +292,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/lib/flutter_facebook_login.dart
+++ b/lib/flutter_facebook_login.dart
@@ -48,6 +48,8 @@ class FacebookLogin {
   ///
   /// NOTE: Updating the login behavior won't do anything immediately; the value
   /// is taken into account just before the login dialog is about to show.
+  ///
+  /// Ignored on iOS, as it's not supported by the iOS Facebook Login SDK anymore.
   set loginBehavior(FacebookLoginBehavior behavior) {
     assert(behavior != null, 'The login behavior cannot be null.');
     _loginBehavior = behavior;
@@ -157,6 +159,8 @@ class FacebookLogin {
 
 /// Different behaviors for controlling how the Facebook Login dialog should
 /// be presented.
+///
+/// Ignored on iOS, as it's not supported by the iOS Facebook Login SDK anymore.
 enum FacebookLoginBehavior {
   /// Login dialog should be rendered by the native Android or iOS Facebook app.
   ///


### PR DESCRIPTION
* Update Android & iOS Facebook Login dependencies to `5.5`
* Removed deprecated method `loginWithPublishPermissions` and renamed `loginWithReadPermission` to `login`
* The `behavior` parameter is now ignored on iOS as it is not supported anymore by the Facebook Login SDK
* #122: Fix expiration date crashes in 32-bit iOS devices.
* Bump iOS deployment target to `9.0`