### PR TITLE
Avoid the "fatal error: module 'FBSDKCoreKit' not found" error on IOS with latest FaceBook SDK

### DIFF
--- a/ios/flutter_facebook_login.podspec
+++ b/ios/flutter_facebook_login.podspec
@@ -20,6 +20,7 @@ A Flutter plugin for allowing users to authenticate with native Android &amp; iO
 
   # https://github.com/flutter/flutter/issues/14161
   s.static_framework = true
+  s.prefix_header_contents = '#define FBSDKCOCOAPODS'
   
   s.ios.deployment_target = '9.0'
 end


### PR DESCRIPTION
I've just added a FBSDKCOCOAPODS define that allows the code to compile, as https://github.com/facebook/facebook-ios-sdk/blob/master/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h is now defined as 

```
#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
#import <FBSDKCoreKit/FBSDKCoreKit.h>
#else
@import FBSDKCoreKit;
#endif

```