### PR TITLE
Workaround to "Reply already submitted"

### DIFF
--- a/android/src/main/java/com/roughike/facebooklogin/facebooklogin/FacebookLoginResultDelegate.java
+++ b/android/src/main/java/com/roughike/facebooklogin/facebooklogin/FacebookLoginResultDelegate.java
@@ -55,7 +55,11 @@ class FacebookLoginResultDelegate implements FacebookCallback<LoginResult>, Plug
 
     private void finishWithResult(Object result) {
         if (pendingResult != null) {
-            pendingResult.success(result);
+            try {
+                pendingResult.success(result);
+            } catch(java.lang.IllegalStateException ex) {
+            }
+            
             pendingResult = null;
         }
     }


### PR DESCRIPTION
java.lang.IllegalStateException: Reply already submitted is thrown sometimes. This will swallow the exception (at least the app won't crash)

Workarounds #86 