### PR TITLE
Don't suggest adding `fbauth` to the application's query schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Once you have the Facebook App ID figured out, then you'll just have to copy-pas
 <array>
     <string>fbapi</string>
     <string>fb-messenger-share-api</string>
-    <string>fbauth2</string>
     <string>fbshareextension</string>
 </array>
 ```


### PR DESCRIPTION
This fixes the redirect loop between the Safari ViewController (SFVC) and the Facebook app mentioned in https://github.com/roughike/flutter_facebook_login/issues/243

After that scheme is removed, the FB SDK seems to build another URL to open in the web view, which doesn't show a button to open the native FB app anymore.
Hence the user just proceeds inside the SFVC with their account, and will be directed straight back to the host app, never taking a "detour" to the FB app.