### PR TITLE
Migrated to null safety

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,7 +21,7 @@ class _MyAppState extends State<MyApp> {
 
     switch (result.status) {
       case FacebookLoginStatus.loggedIn:
-        final FacebookAccessToken accessToken = result.accessToken;
+        final FacebookAccessToken accessToken = result.accessToken!;
         _showMessage('''
          Logged in!
          

--- a/lib/flutter_facebook_login.dart
+++ b/lib/flutter_facebook_login.dart
@@ -51,7 +51,6 @@ class FacebookLogin {
   ///
   /// Ignored on iOS, as it's not supported by the iOS Facebook Login SDK anymore.
   set loginBehavior(FacebookLoginBehavior behavior) {
-    assert(behavior != null, 'The login behavior cannot be null.');
     _loginBehavior = behavior;
   }
 
@@ -82,8 +81,8 @@ class FacebookLogin {
   ///
   /// NOTE: This might return an access token that has expired. If you need to be
   /// sure that the token is still valid, call [isValid] on the access token.
-  Future<FacebookAccessToken> get currentAccessToken async {
-    final Map<dynamic, dynamic> accessToken =
+  Future<FacebookAccessToken?> get currentAccessToken async {
+    final Map<dynamic, dynamic>? accessToken =
         await channel.invokeMethod('getCurrentAccessToken');
 
     if (accessToken == null) {
@@ -104,14 +103,13 @@ class FacebookLogin {
   Future<FacebookLoginResult> logIn(
     List<String> permissions,
   ) async {
-    final Map<dynamic, dynamic> result =
-        await channel.invokeMethod('logIn', {
+    final result = await channel.invokeMethod<Map<dynamic, dynamic>>('logIn', {
       'behavior': _currentLoginBehaviorAsString(),
       'permissions': permissions,
     });
 
     return _deliverResult(
-        FacebookLoginResult._(result.cast<String, dynamic>()));
+        FacebookLoginResult._(result?.cast<String, dynamic>() ?? {}));
   }
 
   /// Logs the currently logged in user out.
@@ -127,8 +125,6 @@ class FacebookLogin {
   Future<void> logOut() async => channel.invokeMethod('logOut');
 
   String _currentLoginBehaviorAsString() {
-    assert(_loginBehavior != null, 'The login behavior was unexpectedly null.');
-
     switch (_loginBehavior) {
       case FacebookLoginBehavior.nativeWithFallback:
         return 'nativeWithFallback';
@@ -139,8 +135,6 @@ class FacebookLogin {
       case FacebookLoginBehavior.webViewOnly:
         return 'webViewOnly';
     }
-
-    throw StateError('Invalid login behavior.');
   }
 
   /// There's a weird bug where calling Navigator.push (or any similar method)
@@ -212,13 +206,13 @@ class FacebookLoginResult {
   ///
   /// Only available when the [status] equals [FacebookLoginStatus.loggedIn],
   /// otherwise null.
-  final FacebookAccessToken accessToken;
+  final FacebookAccessToken? accessToken;
 
   /// The error message when the log in flow completed with an error.
   ///
   /// Only available when the [status] equals [FacebookLoginStatus.error],
   /// otherwise null.
-  final String errorMessage;
+  final String? errorMessage;
 
   FacebookLoginResult._(Map<String, dynamic> map)
       : status = _parseStatus(map['status']),
@@ -229,7 +223,7 @@ class FacebookLoginResult {
             : null,
         errorMessage = map['errorMessage'];
 
-  static FacebookLoginStatus _parseStatus(String status) {
+  static FacebookLoginStatus _parseStatus(String? status) {
     switch (status) {
       case 'loggedIn':
         return FacebookLoginStatus.loggedIn;
@@ -264,10 +258,10 @@ enum FacebookLoginStatus {
 class FacebookAccessToken {
   /// The access token returned by the Facebook login, which can be used to
   /// access Facebook APIs.
-  final String token;
+  final String? token;
 
   /// The id for the user that is associated with this access token.
-  final String userId;
+  final String? userId;
 
   /// The date when this access token expires.
   final DateTime expires;
@@ -277,14 +271,14 @@ class FacebookAccessToken {
   /// These are the permissions that were requested with last login, and which
   /// the user approved. If permissions have changed since the last login, this
   /// list might be outdated.
-  final List<String> permissions;
+  final List<String>? permissions;
 
   /// The list of declined permissions associated with this access token.
   ///
   /// These are the permissions that were requested, but the user didn't
   /// approve. Similarly to [permissions], this list might be outdated if these
   /// permissions have changed since the last login.
-  final List<String> declinedPermissions;
+  final List<String>? declinedPermissions;
 
   /// Is this access token expired or not?
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_facebook_login
 description: A Flutter plugin for allowing users to authenticate with native Android &amp; iOS Facebook login SDKs.
-version: 3.0.0
+version: 3.0.0-nullsafety
 author: Iiro Krankka <iiro.krankka@gmail.com>
 homepage: https://github.com/roughike/flutter_facebook_login
 
@@ -19,4 +19,4 @@ flutter:
     pluginClass: FacebookLoginPlugin
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  sdk: '>=2.12.0-133.7.beta <3.0.0'

--- a/test/facebook_login_test.dart
+++ b/test/facebook_login_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'custom_matchers.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$FacebookLogin', () {
     const channel = MethodChannel('com.roughike/flutter_facebook_login');
 
@@ -41,9 +43,9 @@ void main() {
     };
 
     final log = <MethodCall>[];
-    FacebookLogin sut;
+    late FacebookLogin sut;
 
-    void setMethodCallResponse(Map<String, dynamic> response) {
+    void setMethodCallResponse(Map<String, dynamic>? response) {
       channel.setMockMethodCallHandler((methodCall) {
         log.add(methodCall);
         return Future.value(response);
@@ -94,7 +96,7 @@ void main() {
       setMethodCallResponse(kLoggedInResponse);
 
       final result = await sut.logIn([]);
-      final map = result.accessToken.toMap();
+      final map = result.accessToken!.toMap();
 
       expect(
         map,
@@ -122,13 +124,6 @@ void main() {
       final second = FacebookAccessToken.fromMap(kAccessToken);
 
       expect(first, equals(second));
-    });
-
-    test('loginBehavior - with null argument', () async {
-      setMethodCallResponse(null);
-
-      // Setting a null login behavior is not allowed.
-      expect(() => sut.loginBehavior = null, throwsAssertionError);
     });
 
     test('loginBehavior - nativeWithFallback is the default', () async {
@@ -187,7 +182,7 @@ void main() {
       ]);
 
       expect(result.status, FacebookLoginStatus.loggedIn);
-      expectAccessTokenParsedCorrectly(result.accessToken);
+      expectAccessTokenParsedCorrectly(result.accessToken!);
 
       expect(
         log,
@@ -279,7 +274,7 @@ void main() {
       setMethodCallResponse(kAccessToken);
 
       final accessToken = await sut.currentAccessToken;
-      expectAccessTokenParsedCorrectly(accessToken);
+      expectAccessTokenParsedCorrectly(accessToken!);
     });
 
     test('FacebookAccessToken#isValid() - when not expired, returns true',
@@ -289,7 +284,7 @@ void main() {
       Clock.dateTimeResolver = () => beforeExpiry;
 
       final accessToken = await sut.currentAccessToken;
-      expect(accessToken.isValid(), isTrue);
+      expect(accessToken!.isValid(), isTrue);
     });
 
     test('FacebookAccessToken#isValid() - when expired, returns false',
@@ -299,7 +294,7 @@ void main() {
       Clock.dateTimeResolver = () => afterExpiry;
 
       final accessToken = await sut.currentAccessToken;
-      expect(accessToken.isValid(), isFalse);
+      expect(accessToken!.isValid(), isFalse);
     });
   });
 }


### PR DESCRIPTION
Migrated the package to null safety by running the `dart migrate` tool. In addition to these changes, I removed some now-redundant nullability assertions.

All unit tests still pass (although I did have to add `TestWidgetsFlutterBinding.ensureInitialized()`; not sure what's going on there).